### PR TITLE
fix(script): Clean up voxta-python.bat console output

### DIFF
--- a/patches/python/voxta-python.bat
+++ b/patches/python/voxta-python.bat
@@ -1,15 +1,27 @@
 @echo off
 setlocal
+
 echo Entering Voxta Python Virtual Environment
+echo.
+
 set "PYTHONHOME=%~dp0"
 set "PYTHONPATH=%PYTHONHOME%..\..\..\Resources\Python\Lib\site-packages;%PYTHONHOME%Lib\site-packages\;%PYTHONHOME%Lib\;%PYTHONHOME%DLLs\;%PYTHONHOME%"
 set "PATH=%PYTHONHOME%Scripts;%PATH%"
 set "LIBPATH=%PYTHONHOME%libs"
-echo PYTHONHOME = %PYTHON_HOME%
-echo PYTHONPATH = %PYTHONPATH%
-echo LIBPATH = %LIBPATH%
-echo PATH = %PATH%
-echo Launching cmd with Voxta Python Virtual Environment. Type exit to exit.
+
+REM --- For debugging, you can uncomment the lines below to see the environment variables ---
+REM The original script had a typo: %PYTHON_HOME% should be %PYTHONHOME%
+REM echo PYTHONHOME = %PYTHONHOME%
+REM echo PYTHONPATH = %PYTHONPATH%
+REM echo LIBPATH = %LIBPATH%
+REM The following line was printing a very long string, making the console hard to read.
+REM echo PATH = %PATH%
+
+echo Launching cmd with Voxta Python Virtual Environment.
+echo Type 'exit' to leave.
+echo.
 cmd
+
+echo.
 echo Exited Voxta Python Virtual Environment
 endlocal


### PR DESCRIPTION
This PR addresses a usability issue in the voxta-python.bat script that is packaged with the downloadable Python environment.
Currently, the script echoes several environment variables, including the entire system PATH. This creates a large, messy wall of text in the console that hides the command prompt, making it difficult for developers to use the script for managing packages.


The lines that echo the environment variables (PYTHONHOME, PYTHONPATH, LIBPATH, and PATH) have been commented out. This change results in a clean, welcoming prompt without affecting the script's core functionality.

A minor typo (%PYTHON_HOME% instead of %PYTHONHOME%) was also corrected within the commented-out lines.

BEFORE:
<img width="1724" height="992" alt="image" src="https://github.com/user-attachments/assets/24d74337-1221-4dbb-ac69-51d0190a73dd" />

AFTER:
<img width="1481" height="790" alt="image" src="https://github.com/user-attachments/assets/edef585c-6322-4db3-a8bd-bab983418063" />


