### PR TITLE
Add editdistance cp313 wheel build workflow

### DIFF
--- a/.github/workflows/build-editdistance-wheels.yml
+++ b/.github/workflows/build-editdistance-wheels.yml
@@ -1,0 +1,51 @@
+name: Build and Publish Wheel for editdistance
+
+# editdistance ships no cp313 wheel on PyPI, so pip falls back to compiling the
+# C/Cython extension from source - which fails on end-user machines without a full
+# MSVC + Windows SDK toolchain. Build prebuilt cp313 wheels here for visibility,
+# then upload them to the public.voxta.ai/voxta-python-wheels blob.
+
+on:
+  push:
+    tags:
+      - 'editdistance-*'
+
+jobs:
+  build-and-release:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Clone editdistance repository
+      shell: bash
+      run: git clone --depth 1 --branch v0.8.1 https://github.com/roy-ht/editdistance.git
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install cibuildwheel
+      working-directory: editdistance
+      run: python -m pip install cibuildwheel==2.21.3
+
+    - name: Build
+      working-directory: editdistance
+      run: python -m cibuildwheel --output-dir dist
+      env:
+        CIBW_BUILD: "cp313-*"
+        CIBW_ARCHS_WINDOWS: "AMD64"
+        CIBW_ARCHS_LINUX: "x86_64"
+        CIBW_SKIP: "*-musllinux*"
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: true
+        files: editdistance/dist/*.whl


### PR DESCRIPTION
editdistance ships no cp313 wheel on PyPI, so pip compiles the C/Cython extension from source - which fails on end-user machines lacking a full MSVC + Windows SDK toolchain (the math.h C1083 error). funasr (SenseVoice STT) pulls editdistance in transitively, breaking the Python install for those users.

Mirrors the chroma-hnswlib workflow: cibuildwheel builds cp313 wheels for win_amd64 and manylinux x86_64 on a 'editdistance-*' tag, attaching them to a draft release. Those wheels are then served from the public.voxta.ai/voxta-python-wheels blob and pinned via PythonWheels.EditDistance() in voxta-server.